### PR TITLE
Use node:12-alpine instead of slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:12-alpine
 
 COPY . .
 


### PR DESCRIPTION
Github Actions caches the node:12-alpine image but doesn't cache node:slim. This change saves about 10 seconds when building the image.

https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions