### PR TITLE
Demonstrate |- multiline YAML string in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ steps:
 - uses: actions/first-interaction@v1
   with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
-    issue-message: '# Message with markdown.\nThis is the message that will be displayed on users' first issue.'
-    pr-message: 'Message that will be displayed on users' first pr. Look, a `code block` for markdown.'
+    issue-message: |-
+      # Message with markdown.
+      This is the message that will be displayed on users' first issue.
+    pr-message: |-
+      Message that will be displayed on users' first pr.
+      Look, a `code block` for markdown.
 ```
 
 # License


### PR DESCRIPTION
I like YAML `|-` multiline strings for text with newlines in, rather than needing to include `\n`.