### PR TITLE
Use node version 14.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:14.4.0-buster-slim
 
 COPY . .
 


### PR DESCRIPTION
Node has release version 15.0.0.
`node:slim` therefor has also node version 15.0.0.

For some reason, this is not working in this action.

Reverted to node version 14.4.0

Closes #23