### PR TITLE
Escape single quote on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ steps:
 - uses: actions/first-interaction@v1
   with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
-    issue-message: '# Message with markdown.\nThis is the message that will be displayed on users' first issue.'
-    pr-message: 'Message that will be displayed on users' first pr. Look, a `code block` for markdown.'
+    issue-message: '# Message with markdown.\nThis is the message that will be displayed on users'' first issue.'
+    pr-message: 'Message that will be displayed on users'' first pr. Look, a `code block` for markdown.'
 ```
 
 # License


### PR DESCRIPTION
Example in README has syntax error
https://github.com/actions/first-interaction/issues/8#issuecomment-529619857