### PR TITLE
Use first-interaction in the repository

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,27 @@
+name: first-interaction
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    branches: [main]
+    types: [opened]
+
+jobs:
+  check_for_first_interaction:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/first-interaction@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Hello! Thank you for filing an issue.
+
+            If this is a bug report, please include relevant logs to help us debug the problem.
+          pr-message: |
+            Hello! Thank you for your contribution.
+            
+            If you are fixing a bug, please reference the issue number in the description.
+
+            If you are implementing a feature request, please check with the maintainers that the feature will be accepted first.


### PR DESCRIPTION
We should use this action in the repository to show users what to expect.

Note that I am referencing against `@main` instead of a specific release on purpose.