### PR TITLE
Fix Continuous Integration badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # First Interaction
 
 [![Super-Linter](https://github.com/actions/first-interaction/actions/workflows/linter.yml/badge.svg)](https://github.com/super-linter/super-linter)
-![CI](https://github.com/actions/first-interaction/actions/workflows/ci.yml/badge.svg)
+[![CI](https://github.com/actions/first-interaction/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/actions/first-interaction/actions/workflows/continuous-integration.yml)
 [![Check dist/](https://github.com/actions/first-interaction/actions/workflows/check-dist.yml/badge.svg)](https://github.com/actions/first-interaction/actions/workflows/check-dist.yml)
 [![CodeQL](https://github.com/actions/first-interaction/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/actions/first-interaction/actions/workflows/codeql-analysis.yml)
 [![Coverage](./badges/coverage.svg)](./badges/coverage.svg)


### PR DESCRIPTION
Before:
<img width="914" height="205" alt="Continuous Integration (no status)" src="https://github.com/user-attachments/assets/a38a42c5-1248-49dc-8634-04534ceb98f2" />

After:
<img width="908" height="208" alt="Continuous Integration (passing)" src="https://github.com/user-attachments/assets/d1fa8a94-47ec-4d20-8213-17433ef0c2d5" />
