### PR TITLE
fix: make message parameters optional

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -290,5 +290,39 @@ describe('main.ts', () => {
 
       expect(result).toBe(false)
     })
+
+    it('Skips if is issue and no issue_message is provided', async () => {
+      github.context.payload.issue = { number: 10 }
+      github.context.payload.pull_request = undefined as any
+
+      core.getInput
+        .mockReset()
+        .mockReturnValueOnce('')
+        .mockReturnValueOnce('PR_MESSAGE')
+
+      await main.run()
+
+      expect(core.info).toHaveBeenCalledWith(
+        'Skipping... No issue message configured'
+      )
+      expect(mocktokit.paginate).not.toHaveBeenCalled()
+    })
+
+    it('Skips if is PR and no pr_message is provided', async () => {
+      github.context.payload.issue = undefined as any
+      github.context.payload.pull_request = { number: 10 }
+
+      core.getInput
+        .mockReset()
+        .mockReturnValueOnce('ISSUE_MESSAGE')
+        .mockReturnValueOnce('')
+
+      await main.run()
+
+      expect(core.info).toHaveBeenCalledWith(
+        'Skipping... No PR message configured'
+      )
+      expect(mocktokit.paginate).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export async function run() {
     return core.info('Skipping... No issue message configured')
 
   const prMessage: string = core.getInput('pr_message')
-  if (!isIssue && !prMessage)
+  if (isPullRequest && !prMessage)
     return core.info('Skipping... No PR message configured')
 
   const octokit = new Octokit({

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,10 +28,13 @@ export async function run() {
     )
 
   // Get the action inputs.
-  const issueMessage: string = core.getInput('issue_message', {
-    required: true
-  })
-  const prMessage: string = core.getInput('pr_message', { required: true })
+  const issueMessage: string = core.getInput('issue_message')
+  if (isIssue && !issueMessage)
+    return core.info('Skipping... No issue message configured')
+
+  const prMessage: string = core.getInput('pr_message')
+  if (!isIssue && !prMessage)
+    return core.info('Skipping... No PR message configured')
 
   const octokit = new Octokit({
     auth: core.getInput('repo_token', { required: true })


### PR DESCRIPTION
### Description

The `action.yml` defines both message parameters (`issue_message` and `pr_message`) as not required. Therefore, those parameters should also not be required in the executing code, which otherwise results in an error:

<img width="642" height="391" alt="image" src="https://github.com/user-attachments/assets/4338ba43-db8d-4893-a2a1-82d713e23e5b" />

### Related

- Closes #365 