### PR TITLE
docs: mark issue_message and pr_message as required, clarify token scope

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,14 @@ author: GitHub
 inputs:
   issue_message:
     description: Comment to post on an individual's first issue
+    required: true
   pr_message:
     description: Comment to post on an individual's first pull request
+    required: true
   repo_token:
-    description: Token with permissions to post issue and PR comments
+    description: >-
+      Token used to post comments. Requires `issues: write` and
+      `pull-requests: write` permissions.
     required: true
     default: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
Corrects `action.yml` to accurately reflect the runtime contract enforced by the implementation: `issue_message` and `pr_message` are required inputs, and `repo_token` needs specific GitHub token permission scopes documented explicitly.

## Changes
- Added `required: true` to `issue_message` — was missing despite `core.getInput('issue_message', { required: true })` in `src/main.ts`
- Added `required: true` to `pr_message` — same reason; both messages are always read on every execution regardless of event type
- Replaced the vague `repo_token` description with one that names the exact required permissions: `issues: write` and `pull-requests: write`

## Motivation
The `action.yml` inputs section is the public contract for action consumers and tooling (e.g., Dependabot, VS Code YAML validation, marketplace docs).
Having `issue_message` and `pr_message` appear optional while the runtime unconditionally throws on missing values creates a confusing experience: workflows silently misconfigured at authoring time will fail at runtime with a non-obvious error.

The `repo_token` description gave no guidance on what permissions to grant, forcing users to consult source code or trial-and-error.

## Impact
- **Consumers**: No behavioral change. `required: true` in `action.yml` is metadata only; it does not alter runtime behavior (the code already enforced
this).
- **Tooling / marketplace**: YAML validators and the GitHub Actions marketplace will now correctly flag missing `issue_message` / `pr_message` as errors at
authoring time.
- **Backward compatibility**: Fully backward compatible. No input names, defaults, or runtime behavior changed.

## Testing
- Verified against `src/main.ts`: all three `core.getInput()` calls use `{ required: true }`.
- Confirmed no `core.setOutput()` calls exist (no outputs section needed).
- `action.yml` is valid per the `actionlint.yml` config present in the repo.